### PR TITLE
Adding support for the ESP32c3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,14 @@ build_flags =
 	${common.build_flags}
 	-D NO_BLUETOOTH
 
+[env:esp32c3]
+extends = env:esp32
+board = adafruit_qtpy_esp32c3
+lib_ignore = AsyncTCP_RP2040W
+build_flags =
+	${common.build_flags}
+	-D NO_BLUETOOTH
+
 [env:nodemcuv2]
 extends = common
 platform = espressif8266


### PR DESCRIPTION
# New board

The ESP32c3 Super Mini is a really small and convenient board to use for the ESPAltherma.