### PR TITLE
Enable auth for /webserial as well

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
 	PubSubClient@^2.8
 	ESPAsyncWebServer-esphome@^3.3.0
 	ArduinoJson@^6.21.0
-	asjdf/WebSerialLite@^2.2.0
+	asjdf/WebSerialLite@^2.3.0
 	107-Arduino-MCP2515@^1.5.0
 build_flags =
 	-Wno-error=address

--- a/src/WebUI/webui.cpp
+++ b/src/WebUI/webui.cpp
@@ -1171,7 +1171,10 @@ void WebUI_Init()
   }
 
   // WebSerial is accessible at "<IP Address>/webserial" in browser
-  WebSerial.begin(&server);
+  if(!config->AUTH_ENABLED)
+    WebSerial.begin(&server);
+  else
+    WebSerial.begin(&server, "/webserial", config->AUTH_USERNAME.c_str(), config->AUTH_PASSWORD.c_str());
   WebSerial.onMessage(onWebSerialCallback);
 
   server.on("/", HTTP_GET, onIndex);


### PR DESCRIPTION
Upgraded the webserial lib to the latest version (v2.3.0) with support for [authentication](https://github.com/asjdf/WebSerialLite/commit/f9b2289cb561186a4a3409904539ff5a6580eca6#diff-e9b603fe9e2450ff62d0dd83a65da1c5beca2a6ff2c5e6b7066cb85262b3c147R36). And this time I compiled all the envs :)

Not sure if it matters on the size of the code but the latest webserial lib also switched to [ESPAsyncWebServer-esphome](https://github.com/asjdf/WebSerialLite/commit/792da0b137f9baf0ea376322779629967b4598a3)